### PR TITLE
Fixed critical peformance issues regarding minecraft progression and added progression types

### DIFF
--- a/src/main/java/me/tippie/customadvancements/CustomAdvancements.java
+++ b/src/main/java/me/tippie/customadvancements/CustomAdvancements.java
@@ -86,8 +86,9 @@ public final class CustomAdvancements extends JavaPlugin {
 
 		try {
 			MinecraftAdvancementTreeManager.clearAdvancements(this);
+			Bukkit.reloadData();
 		} catch (IOException e) {
-			getLogger().log(Level.SEVERE, "Failed to clear advancements",e);
+			getLogger().log(Level.WARNING, "Failed to clear advancements, this could happen if there are no advancements.",e);
 		}
 
 		registerAdvancementTypes();

--- a/src/main/java/me/tippie/customadvancements/advancement/AdvancementManager.java
+++ b/src/main/java/me/tippie/customadvancements/advancement/AdvancementManager.java
@@ -8,6 +8,7 @@ import me.tippie.customadvancements.advancement.reward.types.AdvancementRewardTy
 import me.tippie.customadvancements.advancement.reward.types.None;
 import me.tippie.customadvancements.advancement.types.AdvancementType;
 import me.tippie.customadvancements.advancement.types.Empty;
+import org.bukkit.Bukkit;
 import org.bukkit.event.HandlerList;
 
 import java.io.File;
@@ -104,6 +105,7 @@ public class AdvancementManager {
 					MinecraftAdvancementTreeManager.addAdvancements(CustomAdvancements.getInstance(), tree);
 			}
 		}
+		Bukkit.reloadData();
 	}
 
 	/**

--- a/src/main/java/me/tippie/customadvancements/advancement/CAdvancement.java
+++ b/src/main/java/me/tippie/customadvancements/advancement/CAdvancement.java
@@ -1,7 +1,9 @@
 package me.tippie.customadvancements.advancement;
 
 import hu.trigary.advancementcreator.Advancement;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.Setter;
 import lombok.val;
 import me.tippie.customadvancements.CustomAdvancements;
 import me.tippie.customadvancements.advancement.requirement.AdvancementRequirement;
@@ -81,6 +83,11 @@ public class CAdvancement {
 	/**
 	 *
 	 */
+	@Getter @Setter(AccessLevel.PACKAGE) private MinecraftAdvancementTreeManager.ProgressType minecraftProgressType;
+
+	/**
+	 *
+	 */
 	@Getter private Advancement.Frame minecraftGuiFrame;
 
 	@Getter private final boolean minecraftToast;
@@ -107,7 +114,7 @@ public class CAdvancement {
 	 * @param minecraftChatAnnounce
 	 * @see AdvancementType
 	 */
-	CAdvancement(final String type, final String value, final int maxProgress, final String label, final String tree, final List<AdvancementReward> rewards, final List<AdvancementRequirement> requirements, final String displayName, final String description, final ItemStack displayItem, final String guiLocation, final String unit, String minecraftGuiFrame, boolean minecraftToast, boolean minecraftChatAnnounce) {
+	CAdvancement(final String type, final String value, final int maxProgress, final String label, final String tree, final List<AdvancementReward> rewards, final List<AdvancementRequirement> requirements, final String displayName, final String description, final ItemStack displayItem, final String guiLocation, final String unit, String minecraftGuiFrame, boolean minecraftToast, boolean minecraftChatAnnounce, String minecraftProgressType) {
 		this.type = CustomAdvancements.getAdvancementManager().getAdvancementType(type);
 		this.value = value;
 		this.maxProgress = maxProgress;
@@ -130,6 +137,15 @@ public class CAdvancement {
 			}
 		else
 			this.minecraftGuiFrame = Advancement.Frame.TASK;
+
+		if (minecraftProgressType != null) {
+			try {
+				this.minecraftProgressType = MinecraftAdvancementTreeManager.ProgressType.valueOf(minecraftProgressType.toUpperCase());
+			} catch (Exception e){
+				this.minecraftProgressType = MinecraftAdvancementTreeManager.ProgressType.AUTO;
+			}
+		} else
+			this.minecraftProgressType = MinecraftAdvancementTreeManager.ProgressType.AUTO;
 	}
 
 	/**

--- a/src/main/java/me/tippie/customadvancements/advancement/MinecraftAdvancementTreeManager.java
+++ b/src/main/java/me/tippie/customadvancements/advancement/MinecraftAdvancementTreeManager.java
@@ -51,7 +51,13 @@ public class MinecraftAdvancementTreeManager implements Listener {
         final HashMap<String, Advancement> advancements = new HashMap<>();
 
         for (CAdvancement advancement : tree.getAdvancements()) {
-            int triggerCount = Math.max(1, advancement.getMaxProgress());
+            int triggerCount;
+            switch (advancement.getMinecraftProgressType()){
+                case NONE: triggerCount = 1; break;
+                case COUNT: triggerCount = Math.max(1,advancement.getMaxProgress());break;
+                case PERCENTAGE: triggerCount = 100; break;
+                default: triggerCount = 1;
+            }
 
             Advancement newAdvancement = factory.getCountedImpossible(tree.getLabel() + "/" + advancement.getLabel()
                     , root,
@@ -124,5 +130,13 @@ public class MinecraftAdvancementTreeManager implements Listener {
             for(String criteria : bukkitProgress.getRemainingCriteria())
                 bukkitProgress.awardCriteria(criteria);
        });
+    }
+
+
+    public enum ProgressType {
+        AUTO,
+        PERCENTAGE,
+        COUNT,
+        NONE
     }
 }


### PR DESCRIPTION
Fixes #11 
- Adds a `minecraft-progress-type: "PERCENTAGE"` property to advancement display options
- Fixes insane loading times whilst creating advancements trees datapacks